### PR TITLE
Allow "Lock" command to be run by itself.

### DIFF
--- a/pyPSVR.py
+++ b/pyPSVR.py
@@ -182,7 +182,8 @@ if ep:
 
 	# Control 'Cinematic Screen' params
 	if options.size or options.dist or options.mist \
-			or options.bright or options.hdmi:
+			or options.bright or options.hdmi \
+			or options.lock:
 		# Limit size/dist/etc
 		if options.size:
 			if options.size > 100:


### PR DESCRIPTION
Just a small fix that's been bugging me a little. "Lock" was getting set with the "Cinematic" commands, but wasn't getting checked with the if statement. 
